### PR TITLE
No lint on dplyr columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for klmr/box Modules
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # box.linters development version
 
+* Test for dplyr column names
 * Rationalize file names
 * Linting on `box::use(local_module)` patterns
   * All box-attached modules with or without aliases should be used

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,5 +1,6 @@
 Linters
 XPath
+dplyr
 klmr
 linter
 linters

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -1,0 +1,14 @@
+test_that("Should skip columns in dplyr commands", {
+  linters <- lintr::linters_with_defaults(defaults = box.linters::rhino_default_linters)
+
+  code <- "
+box::use(
+  dplyr[`%>%`, filter, select],
+)
+
+mtcars %>%
+  select(mpg, cyl) %>%
+  filter(mpg <= 10)"
+
+  lintr::expect_lint(code, NULL, linters)
+})

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -12,3 +12,18 @@ mtcars %>%
 
   lintr::expect_lint(code, NULL, linters)
 })
+
+test_that("Should skip native pipe `|>` operator", {
+  linters <- lintr::linters_with_defaults(defaults = box.linters::rhino_default_linters)
+
+  code <- "
+box::use(
+  dplyr[filter, select],
+)
+
+mtcars |>
+  select(mpg, cyl) |>
+  filter(mpg <= 10)"
+
+lintr::expect_lint(code, NULL, linters)
+})

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -25,5 +25,5 @@ mtcars |>
   select(mpg, cyl) |>
   filter(mpg <= 10)"
 
-lintr::expect_lint(code, NULL, linters)
+  lintr::expect_lint(code, NULL, linters)
 })


### PR DESCRIPTION
- closes #15

## Changes

- add a unit test for dplyr pipeline with column names

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
