### PR TITLE
R6 modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for klmr/box Modules
-Version: 0.0.0.9009
+Version: 0.0.0.9010
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # box.linters development version
 
+* R6 class awareness
 * Very basic handling of objects inside function definitions
   * Data objects inside function definitions should not lint
   * Functions passed as arguments and used inside function definitions should not lint

--- a/R/box_usage_linter.R
+++ b/R/box_usage_linter.R
@@ -41,8 +41,8 @@ box_usage_linter <- function() {
             split_call_names <- strsplit(fun_call_text, "\\$")[[1]]
             pkg_mod_name_called <- split_call_names[1]
             function_name_called <- split_call_names[2]
-            if (pkg_mod_name_called %in% all_attached_pkg_mod_aliases ||
-                  function_name_called %in% all_attached_pkg_mod_fun_flat) {
+            if (xor(pkg_mod_name_called %in% all_attached_pkg_mod_aliases,
+                  function_name_called %in% all_attached_pkg_mod_fun_flat)) {
               lintr::xml_nodes_to_lints(
                 fun_call,
                 source_expression = source_expression,

--- a/R/box_usage_linter.R
+++ b/R/box_usage_linter.R
@@ -42,7 +42,7 @@ box_usage_linter <- function() {
             pkg_mod_name_called <- split_call_names[1]
             function_name_called <- split_call_names[2]
             if (xor(pkg_mod_name_called %in% all_attached_pkg_mod_aliases,
-                  function_name_called %in% all_attached_pkg_mod_fun_flat)) {
+                    function_name_called %in% all_attached_pkg_mod_fun_flat)) {
               lintr::xml_nodes_to_lints(
                 fun_call,
                 source_expression = source_expression,

--- a/tests/testthat/mod/path/to/module_r6.R
+++ b/tests/testthat/mod/path/to/module_r6.R
@@ -1,0 +1,13 @@
+box::use(
+  R6[R6Class],
+)
+
+#' @export
+SomeClass <- R6Class("SomeClass",    # nolint
+  public = list(
+    char_attribute = "char",
+    method = function() {
+      "method"
+    }
+  )
+)

--- a/tests/testthat/mod/path/to/module_r6.R
+++ b/tests/testthat/mod/path/to/module_r6.R
@@ -3,7 +3,7 @@ box::use(
 )
 
 #' @export
-SomeClass <- R6Class("SomeClass",    # nolint
+some_class <- R6Class("SomeClass",
   public = list(
     char_attribute = "char",
     method = function() {

--- a/tests/testthat/test-box_usage_linter_r6_modules.R
+++ b/tests/testthat/test-box_usage_linter_r6_modules.R
@@ -7,11 +7,11 @@ test_that("box_usage_linter skips allowed R6 object instantiation", {
     R6[R6Class],
   )
 
-  SomeClass <- R6Class(\"SomeClass\",     # nolint
+  some_class <- R6Class(\"SomeClass\",
     public = list()
   )
 
-  s <- SomeClass$new()
+  s <- some_class$new()
   "
 
   lintr::expect_lint(code, NULL, linter)
@@ -21,10 +21,10 @@ test_that("box_usage_linter skips allowed box-imported R6 object instantiation",
   linter <- box_usage_linter()
 
   code <- "box::use(
-    path/to/module_r6[SomeClass]
+    path/to/module_r6[some_class]
   )
 
-  s <- SomeClass$new()
+  s <- some_class$new()
   "
 
   lintr::expect_lint(code, NULL, linter)
@@ -37,7 +37,7 @@ test_that("box_usage_linter skips allowed whole-module-imported R6 object instan
     path/to/module_r6
   )
 
-  s <- module_r6$SomeClass$new()
+  s <- module_r6$some_class$new()
   "
 
   lintr::expect_lint(code, NULL, linter)
@@ -50,12 +50,12 @@ test_that("box_usage_linter skips allowed dynamically added data members to R6 c
     R6[R6Class],
   )
 
-  SomeClass <- R6Class(\"SomeClass\",     # nolint
+  some_class <- R6Class(\"SomeClass\",
     public = list()
   )
 
-  SomeClass$set(\"public\", \"x\", 10)
-  s <- SomeClass$new()
+  some_class$set(\"public\", \"x\", 10)
+  s <- some_class$new()
   s$x
   "
 
@@ -68,11 +68,11 @@ test_that(
     linter <- box_usage_linter()
 
     code <- "box::use(
-      path/to/module_r6[SomeClass]
+      path/to/module_r6[some_class]
     )
 
-    SomeClass$set(\"public\", \"x\", 10)
-    s <- SomeClass$new()
+    some_class$set(\"public\", \"x\", 10)
+    s <- some_class$new()
     s$x
     "
 
@@ -89,8 +89,8 @@ test_that(
       path/to/module_r6
     )
 
-    module_r6$SomeClass$set(\"public\", \"x\", 10)
-    s <- module_r6$SomeClass$new()
+    module_r6$some_class$set(\"public\", \"x\", 10)
+    s <- module_r6$some_class$new()
     s$x
     "
 
@@ -105,14 +105,14 @@ test_that("box_usage_linter skips allowed dynamically added methods to R6 class"
     R6[R6Class],
   )
 
-  SomeClass <- R6Class(\"SomeClass\",     # nolint
+  some_class <- R6Class(\"SomeClass\",
     public = list()
   )
 
-  SomeClass$set(\"public\", \"x\", function() {
+  some_class$set(\"public\", \"x\", function() {
     \"X\"
   })
-  s <- SomeClass$new()
+  s <- some_class$new()
   s$x()
   "
 
@@ -123,13 +123,13 @@ test_that("box_usage_linter skips allowed dynamically added methods to box-impor
   linter <- box_usage_linter()
 
   code <- "box::use(
-    path/to/module_r6[SomeClass]
+    path/to/module_r6[some_class]
   )
 
-  SomeClass$set(\"public\", \"x\", function() {
+  some_class$set(\"public\", \"x\", function() {
     \"X\"
   })
-  s <- SomeClass$new()
+  s <- some_class$new()
   s$x()
   "
 
@@ -145,10 +145,10 @@ test_that(
       path/to/module_r6
     )
 
-    module_r6$SomeClass$set(\"public\", \"x\", function() {
+    module_r6$some_class$set(\"public\", \"x\", function() {
       \"X\"
     })
-    s <- module_r6$SomeClass$new()
+    s <- module_r6$some_class$new()
     s$x()
     "
 
@@ -163,7 +163,7 @@ test_that("box_usage_linter skips allowed R6 object cloning", {
     R6[R6Class],
   )
 
-  SomeClass <- R6Class(\"SomeClass\",     # nolint
+  some_class <- R6Class(\"SomeClass\",
     public = list(
       method = function() {
         \"do something\"
@@ -171,7 +171,7 @@ test_that("box_usage_linter skips allowed R6 object cloning", {
     )
   )
 
-  s <- SomeClass$new()
+  s <- some_class$new()
   t <- s$clone()
   t$method()
   "
@@ -183,10 +183,10 @@ test_that("box_usage_linter skips allowed box-imported R6 object cloning", {
   linter <- box_usage_linter()
 
   code <- "box::use(
-    path/to/module_r6[SomeClass]
+    path/to/module_r6[some_class]
   )
 
-  s <- SomeClass$new()
+  s <- some_class$new()
   t <- s$clone()
   t$method()
   "
@@ -201,7 +201,7 @@ test_that("box_usage_linter skips allowed whole-module-imported R6 object clonin
     path/to/module_r6
   )
 
-  s <- module_r6$SomeClass$new()
+  s <- module_r6$some_class$new()
   t <- s$clone()
   t$method()
   "
@@ -213,7 +213,7 @@ test_that("box_usage_linter skips allowed box-imported aliased R6 object instant
   linter <- box_usage_linter()
 
   code <- "box::use(
-    path/to/module_r6[class_alias = SomeClass]
+    path/to/module_r6[class_alias = some_class]
   )
 
   s <- class_alias$new()
@@ -230,7 +230,7 @@ test_that("box_usage_linter skips allowed whole-module-imported aliased R6 objec
     mod_alias = path/to/module_r6
   )
 
-  s <- mod_alias$SomeClass$new()
+  s <- mod_alias$some_class$new()
   s$method()
   "
 

--- a/tests/testthat/test-box_usage_linter_r6_modules.R
+++ b/tests/testthat/test-box_usage_linter_r6_modules.R
@@ -62,36 +62,41 @@ test_that("box_usage_linter skips allowed dynamically added data members to R6 c
   lintr::expect_lint(code, NULL, linter)
 })
 
-test_that("box_usage_linter skips allowed dynamically added data members to box-imported R6 class", {
-  linter <- box_usage_linter()
+test_that(
+  "box_usage_linter skips allowed dynamically added data members to box-imported R6 class",
+  {
+    linter <- box_usage_linter()
 
-  code <- "box::use(
-    path/to/module_r6[SomeClass]
-  )
+    code <- "box::use(
+      path/to/module_r6[SomeClass]
+    )
 
-  SomeClass$set(\"public\", \"x\", 10)
-  s <- SomeClass$new()
-  s$x
-  "
+    SomeClass$set(\"public\", \"x\", 10)
+    s <- SomeClass$new()
+    s$x
+    "
 
-  lintr::expect_lint(code, NULL, linter)
-})
+    lintr::expect_lint(code, NULL, linter)
+  }
+)
 
-test_that("box_usage_linter skips allowed dynamically added data members to whole-module-imported
-          R6 class", {
-  linter <- box_usage_linter()
+test_that(
+  "box_usage_linter skips allowed dynamically added data members to whole-module-imported R6 class",
+  {
+    linter <- box_usage_linter()
 
-  code <- "box::use(
-    path/to/module_r6
-  )
+    code <- "box::use(
+      path/to/module_r6
+    )
 
-  module_r6$SomeClass$set(\"public\", \"x\", 10)
-  s <- module_r6$SomeClass$new()
-  s$x
-  "
+    module_r6$SomeClass$set(\"public\", \"x\", 10)
+    s <- module_r6$SomeClass$new()
+    s$x
+    "
 
-  lintr::expect_lint(code, NULL, linter)
-})
+    lintr::expect_lint(code, NULL, linter)
+  }
+)
 
 test_that("box_usage_linter skips allowed dynamically added methods to R6 class", {
   linter <- box_usage_linter()
@@ -131,19 +136,102 @@ test_that("box_usage_linter skips allowed dynamically added methods to box-impor
   lintr::expect_lint(code, NULL, linter)
 })
 
-test_that("box_usage_linter skips allowed dynamically added data members to whole-module-imported
-          R6 class", {
-            linter <- box_usage_linter()
+test_that(
+  "box_usage_linter skips allowed dynamically added data members to whole-module-imported R6 class",
+  {
+    linter <- box_usage_linter()
 
-            code <- "box::use(
+    code <- "box::use(
+      path/to/module_r6
+    )
+
+    module_r6$SomeClass$set(\"public\", \"x\", function() {
+      \"X\"
+    })
+    s <- module_r6$SomeClass$new()
+    s$x()
+    "
+
+    lintr::expect_lint(code, NULL, linter)
+  }
+)
+
+test_that("box_usage_linter skips allowed R6 object cloning", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    R6[R6Class],
+  )
+
+  SomeClass <- R6Class(\"SomeClass\",     # nolint
+    public = list(
+      method = function() {
+        \"do something\"
+      }
+    )
+  )
+
+  s <- SomeClass$new()
+  t <- s$clone()
+  t$method()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed box-imported R6 object cloning", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6[SomeClass]
+  )
+
+  s <- SomeClass$new()
+  t <- s$clone()
+  t$method()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed whole-module-imported R6 object cloning", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
     path/to/module_r6
   )
 
-  module_r6$SomeClass$set(\"public\", \"x\", function() {
-    \"X\"
-  })
   s <- module_r6$SomeClass$new()
-  s$x()
+  t <- s$clone()
+  t$method()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed box-imported aliased R6 object instantiation", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6[class_alias = SomeClass]
+  )
+
+  s <- class_alias$new()
+  s$method()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed whole-module-imported aliased R6 object instantiation", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    mod_alias = path/to/module_r6
+  )
+
+  s <- mod_alias$SomeClass$new()
+  s$method()
   "
 
   lintr::expect_lint(code, NULL, linter)

--- a/tests/testthat/test-box_usage_linter_r6_modules.R
+++ b/tests/testthat/test-box_usage_linter_r6_modules.R
@@ -42,3 +42,109 @@ test_that("box_usage_linter skips allowed whole-module-imported R6 object instan
 
   lintr::expect_lint(code, NULL, linter)
 })
+
+test_that("box_usage_linter skips allowed dynamically added data members to R6 class", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    R6[R6Class],
+  )
+
+  SomeClass <- R6Class(\"SomeClass\",     # nolint
+    public = list()
+  )
+
+  SomeClass$set(\"public\", \"x\", 10)
+  s <- SomeClass$new()
+  s$x
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed dynamically added data members to box-imported R6 class", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6[SomeClass]
+  )
+
+  SomeClass$set(\"public\", \"x\", 10)
+  s <- SomeClass$new()
+  s$x
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed dynamically added data members to whole-module-imported
+          R6 class", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6
+  )
+
+  module_r6$SomeClass$set(\"public\", \"x\", 10)
+  s <- module_r6$SomeClass$new()
+  s$x
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed dynamically added methods to R6 class", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    R6[R6Class],
+  )
+
+  SomeClass <- R6Class(\"SomeClass\",     # nolint
+    public = list()
+  )
+
+  SomeClass$set(\"public\", \"x\", function() {
+    \"X\"
+  })
+  s <- SomeClass$new()
+  s$x()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed dynamically added methods to box-imported R6 class", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6[SomeClass]
+  )
+
+  SomeClass$set(\"public\", \"x\", function() {
+    \"X\"
+  })
+  s <- SomeClass$new()
+  s$x()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed dynamically added data members to whole-module-imported
+          R6 class", {
+            linter <- box_usage_linter()
+
+            code <- "box::use(
+    path/to/module_r6
+  )
+
+  module_r6$SomeClass$set(\"public\", \"x\", function() {
+    \"X\"
+  })
+  s <- module_r6$SomeClass$new()
+  s$x()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})

--- a/tests/testthat/test-box_usage_linter_r6_modules.R
+++ b/tests/testthat/test-box_usage_linter_r6_modules.R
@@ -1,0 +1,44 @@
+options(box.path = file.path(getwd(), "mod"))
+
+test_that("box_usage_linter skips allowed R6 object instantiation", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    R6[R6Class],
+  )
+
+  SomeClass <- R6Class(\"SomeClass\",     # nolint
+    public = list()
+  )
+
+  s <- SomeClass$new()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed box-imported R6 object instantiation", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6[SomeClass]
+  )
+
+  s <- SomeClass$new()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})
+
+test_that("box_usage_linter skips allowed whole-module-imported R6 object instantiation", {
+  linter <- box_usage_linter()
+
+  code <- "box::use(
+    path/to/module_r6
+  )
+
+  s <- module_r6$SomeClass$new()
+  "
+
+  lintr::expect_lint(code, NULL, linter)
+})

--- a/tests/testthat/test-get_box_module_exports.R
+++ b/tests/testthat/test-get_box_module_exports.R
@@ -1,7 +1,6 @@
 options(box.path = file.path(getwd(), "mod"))
 
 test_that("get_box_module_exports returns correct list of exported functions", {
-  print(getOption("box.path"))
   module <- "path/to/module_a"
   result <- get_box_module_exports(module)
   expected_output <- c("a_fun_a", "a_fun_b")


### PR DESCRIPTION
Extends from PR #37 

- closes #22 
- closes #23 
- closes #24 
- closes #25 
- closes #26 
- closes #27 
- closes #28 
- closes #29 
- closes #30 

## Changes
- added unit tests and modified a little bit of code to handle R6 classes locally and box-imported

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)



