### PR TITLE
Linting GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
@@ -22,11 +22,11 @@ body:
   - type: textarea
     attributes:
       label: Lint command used
-      value: >
-      lintr::lint(
-        code,
-        linters = lintr::linters_with_defaults(defaults = box.linters::rhino_default_linters)
-      )
+      value: |
+        lintr::lint(
+          code,
+          linters = lintr::linters_with_defaults(defaults = box.linters::rhino_default_linters)
+        )
     validation:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
@@ -1,7 +1,7 @@
 name: 🐞 Linter Bug Report
 description: Report a linting problem you encountered
 labels: ['status: bug']
-title: ['[LINT_BUG]']
+title: '[LINT_BUG]: '
 body:
   - type: markdown
     attributes:
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Sample source code to lint
       description: A snippet of R source code where lint issues are found
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
@@ -27,17 +27,17 @@ body:
           code,
           linters = lintr::linters_with_defaults(defaults = box.linters::rhino_default_linters)
         )
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       label: Lint result
       description: If there was unexpected lint, what was the lint message and at what line?
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       label: Expected result
       description: What should have happened?
-    validation:
+    validations:
       required: true


### PR DESCRIPTION
Issue #63

## Description
* Fixes to get the linting issue template to work

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
