### PR TITLE
[doc bug fix] Wrong function used in the examples in the documentation block

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for klmr/box Modules
-Version: 0.0.0.9013
+Version: 0.0.0.9014
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/R/box_pkg_fun_exists_linter.R
+++ b/R/box_pkg_fun_exists_linter.R
@@ -12,13 +12,13 @@
 #' # will produce lint
 #' lintr::lint(
 #'   text = "box::use(stringr[function_not_exists],)",
-#'   linter = box_mod_fun_exists_linter()
+#'   linter = box_pkg_fun_exists_linter()
 #' )
 #'
 #' # okay
 #' lintr::lint(
 #'   text = "box::use(stringr[str_pad],)",
-#'   linter = box_mod_fun_exists_linter()
+#'   linter = box_pkg_fun_exists_linter()
 #' )
 #' @export
 # nolint end

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 `box.linters` is an R package that provides the [`{lintr}` package](https://github.com/r-lib/lintr/) compatibility with [`{box}` package](https://github.com/klmr/box) modules. In addition to providing code-styling checks for `box::use()` function calls, `box.linters` includes a collection of linter functions to replace [`lintr::object_usage_linter()`](https://lintr.r-lib.org/reference/object_usage_linter.html).
 
-While the primary purpose of `{box.linters}` is for use with the  [`{rhino}`](https://appsilon.github.io/rhino/) package, it's functions and features are available for use with any R code or project that uses the `{box}` package for modular R code.
+While the primary purpose of `{box.linters}` is for use with the  [`{rhino}`](https://appsilon.github.io/rhino/) package, its functions and features are available for use with any R code or project that uses the `{box}` package for modular R code.
 
 ## Motivation
 

--- a/man/box_pkg_fun_exists_linter.Rd
+++ b/man/box_pkg_fun_exists_linter.Rd
@@ -21,12 +21,12 @@ to learn about the details.
 # will produce lint
 lintr::lint(
   text = "box::use(stringr[function_not_exists],)",
-  linter = box_mod_fun_exists_linter()
+  linter = box_pkg_fun_exists_linter()
 )
 
 # okay
 lintr::lint(
   text = "box::use(stringr[str_pad],)",
-  linter = box_mod_fun_exists_linter()
+  linter = box_pkg_fun_exists_linter()
 )
 }


### PR DESCRIPTION
Closes #81 

## Description
* Fixed the wrong function being used in the documentation examples

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
