### PR TITLE
[doc bug fix] for example of package[...]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for klmr/box Modules
-Version: 0.0.0.9013
+Version: 0.0.0.9015
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/R/box_unused_attached_pkg_linter.R
+++ b/R/box_unused_attached_pkg_linter.R
@@ -30,7 +30,7 @@
 #'
 #' code <- "
 #' box::use(
-#'   path/to/stringr[...]
+#'   stringr[...]
 #' )
 #' "
 #'

--- a/man/box_unused_attached_pkg_linter.Rd
+++ b/man/box_unused_attached_pkg_linter.Rd
@@ -38,7 +38,7 @@ lintr::lint(text = code, linters = box_unused_attached_pkg_linter())
 
 code <- "
 box::use(
-  path/to/stringr[...]
+  stringr[...]
 )
 "
 


### PR DESCRIPTION
Closes #79 

## Description
* Example used `path/to/package[...]`. Example should be `package[...]`.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
