### PR TITLE
[doc bug fix] Fix good R6 example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for klmr/box Modules
-Version: 0.0.0.9013
+Version: 0.0.0.9016
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/R/r6_usage_linter.R
+++ b/R/r6_usage_linter.R
@@ -46,7 +46,7 @@
 #'
 #' goodClass <- R6Class('goodClass',
 #'   public = list(
-#'     public_attr,
+#'     public_attr = NULL,
 #'     initialize = function() {
 #'       private$private_func()
 #'     },

--- a/man/r6_usage_linter.Rd
+++ b/man/r6_usage_linter.Rd
@@ -54,7 +54,7 @@ box::use(
 
 goodClass <- R6Class('goodClass',
   public = list(
-    public_attr,
+    public_attr = NULL,
     initialize = function() {
       private$private_func()
     },


### PR DESCRIPTION
Closes #80 

## Description
* In good example, initialize public attribute with NULL value.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
