### PR TITLE
BUG FIX get_attached_modules() should only see modules attached in whole.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.0
+Version: 0.9.0.9001
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* [bugfix] `get_attached_modules()` was not properly finding whole modules attached with short `path/module` declarations
+
 # box.linters 0.9.0
 
 * Handle box-exported functions and objects

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # box.linters (development version)
 
-* [bugfix] `get_attached_modules()` was not properly finding whole modules attached with short `path/module` declarations
+* [bug fix] `get_attached_modules()` was not properly finding whole modules attached with short `path/module` declarations
 
 # box.linters 0.9.0
 

--- a/R/box_module_usage_helper_functions.R
+++ b/R/box_module_usage_helper_functions.R
@@ -26,7 +26,11 @@ get_module_exports <- function(mod_list) {
 get_attached_modules <- function(xml) {
   box_module_import <- "
   /child::expr[
-    child::expr/SYMBOL
+    child::expr/SYMBOL[
+      parent::expr[
+        preceding-sibling::OP-SLASH
+      ]
+    ]
   ]
 "
 

--- a/tests/testthat/test-box_module_usage_halper_functions.R
+++ b/tests/testthat/test-box_module_usage_halper_functions.R
@@ -101,6 +101,108 @@ test_that("get_attached_modules does not return aliased functions", {
   expect_setequal(results$nested$module_b, module_b_objects)
 })
 
+
+#### Test different path structure
+options(box.path = file.path(getwd(), "mod", "path"))
+
+test_that("get_attached_modules returns correct list of imported whole modules", {
+  whole_imported_modules <- "
+  box::use(
+    to/module_a,
+    to/module_b
+  )
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+  expected_results <- c("module_a", "module_b")
+
+  expect_equal(names(results$nested), expected_results)
+
+  module_a_objects <- c("a_fun_a", "a_fun_b")
+  expect_setequal(results$nested$module_a, module_a_objects)
+
+  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+  expect_setequal(results$nested$module_b, module_b_objects)
+})
+
+test_that("get_attached_modules does not return modules imported with '...'", {
+  whole_imported_modules <- "
+  box::use(
+    to/module_a[...],
+    to/module_b
+  )
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+  expected_results <- c("module_b")
+
+  expect_equal(names(results$nested), expected_results)
+
+  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+  expect_setequal(results$nested$module_b, module_b_objects)
+})
+
+test_that("get_attached_modules does not return modules imported with functions", {
+  whole_imported_modules <- "
+  box::use(
+    to/module_a[a_fun_a, a_fun_b],
+    to/module_b
+  )
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+  expected_results <- c("module_b")
+
+  expect_equal(names(results$nested), expected_results)
+
+  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+  expect_setequal(results$nested$module_b, module_b_objects)
+})
+
+test_that("get_attached_modules returns correct list of aliased imported whole modules", {
+  whole_imported_modules <- "
+  box::use(
+    mod_alias = to/module_a,
+    to/module_b
+  )
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+
+  expected_results <- c("mod_alias", "module_b")
+  expect_equal(names(results$nested), expected_results)
+
+  names(expected_results) <- c("module_a", "module_b")
+  expect_equal(results$aliases, expected_results)
+})
+
+test_that("get_attached_modules does not return aliased functions", {
+  whole_imported_modules <- "
+  box::use(
+    to/module_a[fun_alias = a_fun_a, a_fun_b],
+    to/module_b
+  )
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+  expected_results <- c("module_b")
+
+  expect_equal(names(results$nested), expected_results)
+
+  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+  expect_setequal(results$nested$module_b, module_b_objects)
+})
+
+# Reset box path
+options(box.path = file.path(getwd(), "mod"))
+####
+
+
 test_that("get_attached_modules does not return imported packages", {
   whole_imported_modules <- "
   box::use(

--- a/tests/testthat/test-box_module_usage_halper_functions.R
+++ b/tests/testthat/test-box_module_usage_halper_functions.R
@@ -101,107 +101,105 @@ test_that("get_attached_modules does not return aliased functions", {
   expect_setequal(results$nested$module_b, module_b_objects)
 })
 
+withr::with_options(
+  list(
+    box.path = file.path(getwd(), "mod", "path")
+  ),
+  {
+    test_that("get_attached_modules returns correct list of imported whole modules", {
+      whole_imported_modules <- "
+      box::use(
+        to/module_a,
+        to/module_b
+      )
+      "
 
-#### Test different path structure
-options(box.path = file.path(getwd(), "mod", "path"))
+      xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+      results <- get_attached_modules(xml_whole_imported_modules)
+      expected_results <- c("module_a", "module_b")
 
-test_that("get_attached_modules returns correct list of imported whole modules", {
-  whole_imported_modules <- "
-  box::use(
-    to/module_a,
-    to/module_b
-  )
-  "
+      expect_equal(names(results$nested), expected_results)
 
-  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
-  results <- get_attached_modules(xml_whole_imported_modules)
-  expected_results <- c("module_a", "module_b")
+      module_a_objects <- c("a_fun_a", "a_fun_b")
+      expect_setequal(results$nested$module_a, module_a_objects)
 
-  expect_equal(names(results$nested), expected_results)
+      module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+      expect_setequal(results$nested$module_b, module_b_objects)
+    })
 
-  module_a_objects <- c("a_fun_a", "a_fun_b")
-  expect_setequal(results$nested$module_a, module_a_objects)
+    test_that("get_attached_modules does not return modules imported with '...'", {
+      whole_imported_modules <- "
+      box::use(
+        to/module_a[...],
+        to/module_b
+      )
+      "
 
-  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
-  expect_setequal(results$nested$module_b, module_b_objects)
-})
+      xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+      results <- get_attached_modules(xml_whole_imported_modules)
+      expected_results <- c("module_b")
 
-test_that("get_attached_modules does not return modules imported with '...'", {
-  whole_imported_modules <- "
-  box::use(
-    to/module_a[...],
-    to/module_b
-  )
-  "
+      expect_equal(names(results$nested), expected_results)
 
-  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
-  results <- get_attached_modules(xml_whole_imported_modules)
-  expected_results <- c("module_b")
+      module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+      expect_setequal(results$nested$module_b, module_b_objects)
+    })
 
-  expect_equal(names(results$nested), expected_results)
+    test_that("get_attached_modules does not return modules imported with functions", {
+      whole_imported_modules <- "
+      box::use(
+        to/module_a[a_fun_a, a_fun_b],
+        to/module_b
+      )
+      "
 
-  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
-  expect_setequal(results$nested$module_b, module_b_objects)
-})
+      xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+      results <- get_attached_modules(xml_whole_imported_modules)
+      expected_results <- c("module_b")
 
-test_that("get_attached_modules does not return modules imported with functions", {
-  whole_imported_modules <- "
-  box::use(
-    to/module_a[a_fun_a, a_fun_b],
-    to/module_b
-  )
-  "
+      expect_equal(names(results$nested), expected_results)
 
-  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
-  results <- get_attached_modules(xml_whole_imported_modules)
-  expected_results <- c("module_b")
+      module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+      expect_setequal(results$nested$module_b, module_b_objects)
+    })
 
-  expect_equal(names(results$nested), expected_results)
+    test_that("get_attached_modules returns correct list of aliased imported whole modules", {
+      whole_imported_modules <- "
+      box::use(
+        mod_alias = to/module_a,
+        to/module_b
+      )
+      "
 
-  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
-  expect_setequal(results$nested$module_b, module_b_objects)
-})
+      xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+      results <- get_attached_modules(xml_whole_imported_modules)
 
-test_that("get_attached_modules returns correct list of aliased imported whole modules", {
-  whole_imported_modules <- "
-  box::use(
-    mod_alias = to/module_a,
-    to/module_b
-  )
-  "
+      expected_results <- c("mod_alias", "module_b")
+      expect_equal(names(results$nested), expected_results)
 
-  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
-  results <- get_attached_modules(xml_whole_imported_modules)
+      names(expected_results) <- c("module_a", "module_b")
+      expect_equal(results$aliases, expected_results)
+    })
 
-  expected_results <- c("mod_alias", "module_b")
-  expect_equal(names(results$nested), expected_results)
+    test_that("get_attached_modules does not return aliased functions", {
+      whole_imported_modules <- "
+      box::use(
+        to/module_a[fun_alias = a_fun_a, a_fun_b],
+        to/module_b
+      )
+      "
 
-  names(expected_results) <- c("module_a", "module_b")
-  expect_equal(results$aliases, expected_results)
-})
+      xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+      results <- get_attached_modules(xml_whole_imported_modules)
+      expected_results <- c("module_b")
 
-test_that("get_attached_modules does not return aliased functions", {
-  whole_imported_modules <- "
-  box::use(
-    to/module_a[fun_alias = a_fun_a, a_fun_b],
-    to/module_b
-  )
-  "
+      expect_equal(names(results$nested), expected_results)
 
-  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
-  results <- get_attached_modules(xml_whole_imported_modules)
-  expected_results <- c("module_b")
-
-  expect_equal(names(results$nested), expected_results)
-
-  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
-  expect_setequal(results$nested$module_b, module_b_objects)
-})
-
-# Reset box path
-options(box.path = file.path(getwd(), "mod"))
-####
-
+      module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+      expect_setequal(results$nested$module_b, module_b_objects)
+    })
+  }
+)
 
 test_that("get_attached_modules does not return imported packages", {
   whole_imported_modules <- "


### PR DESCRIPTION
Closes #87 

## Description
* Added extra explicit path to the XML Xpath query to properly identify modules attached in whole
* Added unit tests to handle `path/module` in addition to existing `path/to/module`
* Refer to #87 for bug description

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
