### PR TITLE
[Bug Fix] `box_unused_att_pkg_fun_linter()` to handle attached list of functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.0
+Version: 0.9.0.9002
 Authors@R:
   c(
-    person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),
+    person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),
     person("Jakub", "Nowicki", role = "aut", email = "kuba@appsilon.com"),
     person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# box.linters (development version)
+
+* [bug fix] `box_unused_att_pkg_fun_linter()` had issues with lists of functions. Linter function
+  now drops the nested function name and retains the list name (`list_name$function_name()`) when
+  performing the check.
+
 # box.linters 0.9.0
 
 * Handle box-exported functions and objects

--- a/R/box_unused_attached_pkg_fun_linter.R
+++ b/R/box_unused_attached_pkg_fun_linter.R
@@ -61,6 +61,14 @@ box_unused_att_pkg_fun_linter <- function() {
     attached_functions <- get_attached_pkg_functions(xml)
     function_calls <- get_function_calls(xml)
 
+    # Flatten list function call to list object name
+    function_calls$text <- vapply(
+      strsplit(function_calls$text, "\\$"),
+      `[`,
+      1,
+      FUN.VALUE = character(1)
+    )
+
     lapply(attached_functions$xml, function(fun_import) {
       fun_import_text <- xml2::xml_text(fun_import)
       fun_import_text <- gsub("[`'\"]", "", fun_import_text)

--- a/tests/testthat/mod/path/to/module_d.R
+++ b/tests/testthat/mod/path/to/module_d.R
@@ -1,0 +1,9 @@
+#' @export
+function_list <- list(
+  fun_a = function() {
+    "list function a"
+  },
+  fun_b = function() {
+    "list function b"
+  }
+)

--- a/tests/testthat/test-box_unused_attached_mod_obj_linter.R
+++ b/tests/testthat/test-box_unused_attached_mod_obj_linter.R
@@ -114,3 +114,28 @@ test_that("box_unused_att_mod_obj_linter blocks box-attached aliased objects unu
 
   lintr::expect_lint(bad_box_usage_1, list(message = lint_message_1), linter)
 })
+
+test_that("box_unused_att_mod_obj_linter skips used function in list", {
+  linter <- box_unused_att_mod_obj_linter()
+
+  good_box_usage <- "box::use(
+    path/to/module_d[function_list]
+  )
+
+  function_list$fun_a()
+  "
+
+  lintr::expect_lint(good_box_usage, NULL, linter)
+})
+
+test_that("box_unused_att_mod_obj_linter blocks used function in list", {
+  linter <- box_unused_att_mod_obj_linter()
+  lint_message <- rex::rex("Imported function/object unused.")
+
+  bad_box_usage <- "box::use(
+    path/to/module_d[function_list]
+  )
+  "
+
+  lintr::expect_lint(bad_box_usage, list(message = lint_message), linter)
+})

--- a/tests/testthat/test-box_unused_attached_pkg_fun_linter.R
+++ b/tests/testthat/test-box_unused_attached_pkg_fun_linter.R
@@ -94,3 +94,28 @@ test_that("box_unused_attached_fun_linter blocks box-attached aliased functions 
 
   lintr::expect_lint(bad_box_usage_1, list(message = lint_message_1), linter)
 })
+
+test_that("box_unused_att_pkg_fun_linter skips used function in list", {
+  linter <- box_unused_att_pkg_fun_linter()
+
+  good_box_usage <- "box::use(
+    shiny[tags],
+  )
+
+  tags$h1('Header')
+  "
+
+  lintr::expect_lint(good_box_usage, NULL, linter)
+})
+
+test_that("box_unused_att_pkg_fun_linter blocks unused function in list", {
+  linter <- box_unused_att_pkg_fun_linter()
+  lint_message <- rex::rex("Imported function unused.")
+
+  bad_box_usage <- "box::use(
+    shiny[tags],
+  )
+  "
+
+  lintr::expect_lint(bad_box_usage, list(message = lint_message), linter)
+})


### PR DESCRIPTION
Closes #88

## Description
* Linter now drops the nested function name and retains the container list name (`list_names$function_name()`)

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
