### PR TITLE
Bug fix. Trailing commas and comments (nolint) at the last entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.0
+Version: 0.9.0.9003
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* [bug fix] box_trailing_commas_linter() now properly handles a #nolint for other linters
+
 # box.linters 0.9.0
 
 * Handle box-exported functions and objects

--- a/R/box_trailing_commas_linter.R
+++ b/R/box_trailing_commas_linter.R
@@ -56,7 +56,12 @@ box_trailing_commas_linter <- function(check_functions = FALSE) {
   right_paren_xpath <- paste(
     base_xpath,
     "/following-sibling::OP-RIGHT-PAREN[
-       preceding-sibling::*[1][not(self::OP-COMMA)]
+        preceding-sibling::*[1][
+          not(self::OP-COMMA) and
+          not(self::COMMENT[
+            preceding-sibling::OP-COMMA
+          ])
+        ]
       ]
     "
   )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,7 +1,7 @@
 Appsilon
 CMD
-Customizable
 Codecov
+Customizable
 Github
 Linters
 RStudio
@@ -10,8 +10,8 @@ XPath
 appsilon
 config
 dplyr
-klmr
 linter
 linters
 lintr
+nolint
 preconfigured

--- a/tests/testthat/test-box_trailing_commas_linter.R
+++ b/tests/testthat/test-box_trailing_commas_linter.R
@@ -103,3 +103,37 @@ test_that("box_trailing_commas_linter should not lint outside of `box::use()`", 
 
   lintr::expect_lint(should_not_lint, NULL, linter)
 })
+
+test_that("box_trailing_commas_linter should ignore comments", {
+  linter <- box_trailing_commas_linter()
+
+  with_comment <- "box::use(
+    dplyr[...],   # some comment
+  )
+  "
+
+  lintr::expect_lint(with_comment, NULL, linter)
+})
+
+test_that("box_trailing_commas_linter should ignore nolint for other linters", {
+  linter <- box_trailing_commas_linter()
+
+  with_comment <- "box::use(
+    dplyr[...],   # nolint: box_universal_import_linter
+  )
+  "
+
+  lintr::expect_lint(with_comment, NULL, linter)
+})
+
+test_that("box_trailing_commas_linter blocks comment in last entry, no comma", {
+  linter <- box_trailing_commas_linter()
+  paren_lint_msg <- rex::rex("Always have a trailing comma at the end of imports, before a `)`.")
+
+  with_comment <- "box::use(
+    dplyr[...]   # some comment
+  )
+  "
+
+  lintr::expect_lint(with_comment, list(message = paren_lint_msg), linter)
+})


### PR DESCRIPTION
Closes #89 

## Description
* Handle comments at the last line before the closing `)`.
* Refer to notes in #89 

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
