### PR TITLE
Add missing box_mod_fun_exists_linter() to default linters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.0
+Version: 0.9.0.9004
 Authors@R:
   c(
     person("Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* Added box_mod_fun_exists_linter() to default linters 
+
 # box.linters 0.9.0
 
 * Handle box-exported functions and objects

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,6 +15,7 @@ rhino_default_linters <- lintr::modify_defaults(
   defaults = lintr::default_linters,
   box_alphabetical_calls_linter = box_alphabetical_calls_linter(),
   box_func_import_count_linter = box_func_import_count_linter(),
+  box_mod_fun_exists_linter = box_mod_fun_exists_linter(),
   box_pkg_fun_exists_linter = box_pkg_fun_exists_linter(),
   box_separate_calls_linter = box_separate_calls_linter(),
   box_trailing_commas_linter = box_trailing_commas_linter(),
@@ -41,6 +42,7 @@ rhino_default_linters <- lintr::modify_defaults(
 #' @export
 box_default_linters <- lintr::modify_defaults(
   defaults = lintr::default_linters,
+  box_mod_fun_exists_linter = box_mod_fun_exists_linter(),
   box_pkg_fun_exists_linter = box_pkg_fun_exists_linter(),
   box_unused_attached_mod_linter = box_unused_attached_mod_linter(),
   box_unused_att_mod_obj_linter = box_unused_att_mod_obj_linter(),

--- a/man/box_default_linters.Rd
+++ b/man/box_default_linters.Rd
@@ -5,7 +5,7 @@
 \alias{box_default_linters}
 \title{Box-compatible default linters}
 \format{
-An object of class \code{list} of length 32.
+An object of class \code{list} of length 33.
 }
 \usage{
 box_default_linters

--- a/man/rhino_default_linters.Rd
+++ b/man/rhino_default_linters.Rd
@@ -5,7 +5,7 @@
 \alias{rhino_default_linters}
 \title{Rhino default linters}
 \format{
-An object of class \code{list} of length 37.
+An object of class \code{list} of length 38.
 }
 \usage{
 rhino_default_linters


### PR DESCRIPTION
Closes #93 

## Description
* `box_mod_fun_exists_linter()` was missing in both default linters. Added.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
