### PR TITLE
chore: Fix the code coverage badge missing on the documentation page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/box.linters)](https://cran.r-project.org/package=box.linters)
 [![R-CMD-check](https://github.com/Appsilon/box.linters/workflows/CI/badge.svg)](https://github.com/Appsilon/box.linters/actions/workflows/ci.yml)
-![Codecov test coverage](https://codecov.io/gh/Appsilon/box.linters/branch/main/graph/badge.svg)
+[![Codecov test coverage](https://codecov.io/gh/Appsilon/box.linters/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Appsilon/box.linters)
 <!-- badges: end -->
 
 `box.linters` is an R package that provides the [`{lintr}` package](https://github.com/r-lib/lintr/) compatibility with [`{box}` package](https://github.com/klmr/box) modules. In addition to providing code-styling checks for `box::use()` function calls, `box.linters` includes a collection of linter functions to replace [`lintr::object_usage_linter()`](https://lintr.r-lib.org/reference/object_usage_linter.html).


### PR DESCRIPTION
Before:
![image](https://github.com/Appsilon/box.linters/assets/7279715/d17c6ebb-c879-43ab-ad17-61ed2ac79967)
After:
![image](https://github.com/Appsilon/box.linters/assets/7279715/80491072-57c6-40b5-882b-7d6bbf762a95)
