### PR TITLE
chore: remove pre-rhino 1.8.0 warning

### DIFF
--- a/vignettes/how-to/rhino-default.Rmd
+++ b/vignettes/how-to/rhino-default.Rmd
@@ -16,8 +16,6 @@ knitr::opts_chunk$set(
 
 ## Rhino (>= 1.8.0)
 
-> Rhino 1.8.0 may not yet be available at the time of this release.
-
 Projects created with `rhino` version 1.8.0 and later come preconfigured with a `.lintr` file. 
 
 ```{yaml}


### PR DESCRIPTION
- Closes #75 

## Description
* Remove one line in the how-to article for Rhino.
* Package version intentionally not updated.


## Definition of Done
- [x] The change is thoroughly documented.
- [x] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
