### PR TITLE
Require lintr >= 3.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
   cli,
   fs,
   glue,
-  lintr (>= 3.0.0),
+  lintr (>= 3.1.0),
   rlang,
   stringr,
   xml2,


### PR DESCRIPTION
Closes #109. We are using `lintr::get_r_string()` which was introduced in [lintr 3.1.0](https://github.com/r-lib/lintr/releases/tag/v3.1.0), so we need to require at least that version. Issue detected while [test-upgrading](https://github.com/Appsilon/rhino-showcase/pull/41) Rhino Showcase for the upcoming Rhino 1.9.0.