### PR TITLE
bug fix #111. allow multiple box::use() calls for packages and modules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.1
+Version: 0.9.1.9002
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.9.1.9002
+Version: 0.9.1.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* [Bugfix] Allow multiple `box::use(pkg)` calls (#111)
+
 # box.linters 0.9.1
 
 * Handle `box` recommended method of testing private methods.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # box.linters (development version)
 
-* [Bugfix] Allow multiple `box::use(pkg)` calls (#111)
+* [Bug fix] Allow multiple `box::use(pkg)` calls (#111)
 
 # box.linters 0.9.1
 

--- a/R/box_module_usage_helper_functions.R
+++ b/R/box_module_usage_helper_functions.R
@@ -55,7 +55,11 @@ get_attached_modules <- function(xml) {
   xpath_whole_modules <- paste(box_module_base_path(), whole_module_imports)
   xml_whole_modules <- xml2::xml_find_all(xml, xpath_whole_modules)
 
-  aliased_whole_modules <- paste0(xml2::xml_text(xml_whole_modules), collapse = "")
+  xml_whole_modules_text <- xml2::xml_text(xml_whole_modules)
+
+  hacky_comma_fix <- hacky_comma_fix(xml_whole_modules_text)
+
+  aliased_whole_modules <- paste0(hacky_comma_fix, collapse = "")
   mods <- strsplit(gsub("`", "", aliased_whole_modules), ",")[[1]]
   output <- do.call(rbind, strsplit(mods, "="))
 

--- a/tests/testthat/test-box_module_usage_halper_functions.R
+++ b/tests/testthat/test-box_module_usage_halper_functions.R
@@ -29,6 +29,28 @@ test_that("get_attached_modules returns correct list of imported whole modules",
   expect_setequal(results$nested$module_b, module_b_objects)
 })
 
+test_that("get_attached_modules returns correct list of imported whole modules in separate calls", {
+  whole_imported_modules <- "
+  box::use(path/to/module_a)
+  box::use(alias = path/to/module_b, path/to/module_c)
+  "
+
+  xml_whole_imported_modules <- code_to_xml_expr(whole_imported_modules)
+  results <- get_attached_modules(xml_whole_imported_modules)
+  expected_results <- c("module_a", "alias", "module_c")
+
+  expect_equal(names(results$nested), expected_results)
+
+  module_a_objects <- c("a_fun_a", "a_fun_b")
+  expect_setequal(results$nested$module_a, module_a_objects)
+
+  module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+  expect_setequal(results$nested$alias, module_b_objects)
+
+  module_c_objects <- c("c_fun_a", "c_fun_b", "c_obj_a")
+  expect_setequal(results$nested$module_c, module_c_objects)
+})
+
 test_that("get_attached_modules does not return modules imported with '...'", {
   whole_imported_modules <- "
   box::use(
@@ -246,6 +268,26 @@ test_that("get_attached_mod_three_dots returns correct list of imported function
 
   expect_setequal(results$text, c(module_a_objects, module_b_objects))
 })
+
+test_that(
+  "get_attached_mod_three_dots returns correct list of imported functions in separate calls", {
+    three_dots_import <- "
+  box::use(path/to/module_a[...])
+  box::use(path/to/module_b[...])
+  "
+
+    xml_three_dots_modules <- code_to_xml_expr(three_dots_import)
+    results <- get_attached_mod_three_dots(xml_three_dots_modules)
+
+    module_a_objects <- c("a_fun_a", "a_fun_b")
+    module_b_objects <- c("b_fun_a", "b_fun_b", "b_obj_a")
+
+    expect_setequal(results$nested$module_a, module_a_objects)
+    expect_setequal(results$nested$module_b, module_b_objects)
+
+    expect_setequal(results$text, c(module_a_objects, module_b_objects))
+  }
+)
 
 test_that("get_attached_mod_three_dots does not return whole imported modules", {
   three_dots_import <- "

--- a/tests/testthat/test-box_package_usage_helper_functions.R
+++ b/tests/testthat/test-box_package_usage_helper_functions.R
@@ -27,6 +27,36 @@ test_that("get_attached_packages returns correct list of imported whole packages
   expect_setequal(results$nested$stringr, stringr_functions)
 })
 
+test_that(
+  "get_attached_packages returns correct list of imported whole packages in
+separate box::use calls", {
+    whole_imported_packages <- "
+  box::use(
+    dplyr,
+    stringr,
+  )
+  box::use(
+    fs
+  )
+  "
+
+    xml_whole_imported_packages <- code_to_xml_expr(whole_imported_packages)
+    results <- get_attached_packages(xml_whole_imported_packages)
+    expected_results <- c("dplyr", "stringr", "fs")
+
+    expect_equal(names(results$nested), expected_results)
+
+    dplyr_functions <- getNamespaceExports("dplyr")
+    expect_setequal(results$nested$dplyr, dplyr_functions)
+
+    stringr_functions <- getNamespaceExports("stringr")
+    expect_setequal(results$nested$stringr, stringr_functions)
+
+    fs_functions <- getNamespaceExports("fs")
+    expect_setequal(results$nested$fs, fs_functions)
+  }
+)
+
 test_that("get_attached_packages does not return packages imported with '...'", {
   whole_imported_packages <- "
   box::use(
@@ -132,6 +162,26 @@ test_that("get_attached_pkg_three_dots returns correct list of imported function
 
   expect_setequal(results$text, c(dplyr_results, stringr_results))
 })
+
+test_that(
+  "get_attached_pkg_three_dots separate box::use returns correct list of imported functions", {
+    three_dots_import <- "
+  box::use(dplyr[...])
+  box::use(stringr[...])
+  "
+
+    xml_three_dots_packages <- code_to_xml_expr(three_dots_import)
+    results <- get_attached_pkg_three_dots(xml_three_dots_packages)
+
+    dplyr_results <- getNamespaceExports("dplyr")
+    stringr_results <- getNamespaceExports("stringr")
+
+    expect_setequal(results$nested$dplyr, dplyr_results)
+    expect_setequal(results$nested$stringr, stringr_results)
+
+    expect_setequal(results$text, c(dplyr_results, stringr_results))
+  }
+)
 
 test_that("get_attached_pkg_three_dots does not return whole imported packages", {
   three_dots_import <- "


### PR DESCRIPTION
Closes #111 

## Description
* allows multiple separate `box::use()` calls for both packages and modules
* new function to manage multiple box::use() calls to fit in current architecture/algorithm
* `box` [PR](https://github.com/klmr/box/pull/369) may be a better solution in the future.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
