### PR TITLE
Implement exclude_files in style_box_use_dir()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.2
+Version: 0.10.2.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),
@@ -15,7 +15,7 @@ URL: https://appsilon.github.io/box.linters/, https://github.com/Appsilon/box.li
 License: LGPL-3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends:
   R (>= 2.10)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* Implement `exclude_files` in `style_box_use_dir()` to exclude files from styling.
+
 # box.linters 0.10.2
 
 * Implemented linter tags file compatible with `lintr::available_linters()` and

--- a/R/style_box_use.R
+++ b/R/style_box_use.R
@@ -2,7 +2,8 @@
 #'
 #' @param path Path to a directory with files to style.
 #' @param recursive A logical value indicating whether or not files in sub-directories
-#' @param exclude_files *Not yet implemented*
+#' @param exclude_files A character vector of regular expressions to exclude files (not paths)
+#' from styling.
 #' @param exclude_dirs A character vector of directories to exclude.
 #' @param indent_spaces An integer scalar indicating tab width in units of spaces
 #' @param trailing_commas_func A boolean to activate adding a trailing comma to the end of the lists
@@ -14,13 +15,16 @@
 #' @examples
 #' \dontrun{
 #' style_box_use_dir("path/to/dir")
+#'
+#' # to exclude `__init__.R` files from styling
+#' style_box_use_dir("path/to/dir", exclude_files = c("__init__\\.R"))
 #' }
 #'
 #' @export
 style_box_use_dir <- function(
   path = ".",
   recursive = TRUE,
-  exclude_files = NULL,
+  exclude_files = c(),
   exclude_dirs = c("packrat", "renv"),
   indent_spaces = 2,
   trailing_commas_func = FALSE
@@ -63,6 +67,12 @@ style_box_use_files <- function(
   regex_excluded_dirs <- paste(exclude_dirs, collapse = "|")
   files <- fs::dir_ls(".", regexp = "\\.[rR]$", recurse = recursive, all = FALSE)
   files <- files[stringr::str_starts(files, regex_excluded_dirs, negate = TRUE)]
+
+  if (!is.null(exclude_files)) {
+    regex_excluded_files <- paste(exclude_files, collapse = "|")
+    files <- files[stringr::str_ends(files, regex_excluded_files, negate = TRUE)]
+  }
+
   purrr::map(files, transform_file, indent_spaces, trailing_commas_func)
 }
 

--- a/man/style_box_use_dir.Rd
+++ b/man/style_box_use_dir.Rd
@@ -7,7 +7,7 @@
 style_box_use_dir(
   path = ".",
   recursive = TRUE,
-  exclude_files = NULL,
+  exclude_files = c(),
   exclude_dirs = c("packrat", "renv"),
   indent_spaces = 2,
   trailing_commas_func = FALSE
@@ -18,7 +18,8 @@ style_box_use_dir(
 
 \item{recursive}{A logical value indicating whether or not files in sub-directories}
 
-\item{exclude_files}{\emph{Not yet implemented}}
+\item{exclude_files}{A character vector of regular expressions to exclude files (not paths)
+from styling.}
 
 \item{exclude_dirs}{A character vector of directories to exclude.}
 
@@ -36,6 +37,9 @@ Refer to \code{\link[=style_box_use_text]{style_box_use_text()}} for styling det
 \examples{
 \dontrun{
 style_box_use_dir("path/to/dir")
+
+# to exclude `__init__.R` files from styling
+style_box_use_dir("path/to/dir", exclude_files = c("__init__\\\\.R"))
 }
 
 }

--- a/tests/testthat/test-style_box_use.R
+++ b/tests/testthat/test-style_box_use.R
@@ -1433,6 +1433,7 @@ test_that("style_box_use_dir() properly styles file in a directory", {
     result <- suppressWarnings(style_box_use_dir("to_style"))
 
     expected_result <- list(
+      "app/__init__.R" = TRUE,
       "app/app_1.R" = TRUE,
       "main.R" = TRUE
     )
@@ -1449,5 +1450,21 @@ test_that("style_box_use_dir() properly styles file in a directory", {
     fs::dir_copy(to_style_path, "to_style")
 
     expect_warning(style_box_use_dir("to_style"), expected_warning)
+  })
+})
+
+test_that("style_box_use_dir() does not style files in exclude_files", {
+  to_style_path <- normalizePath("to_style")
+  exclude_files <- c("__init__\\.R")
+
+  withr::with_tempdir({
+    fs::dir_copy(to_style_path, "to_style")
+
+    suppressWarnings(style_box_use_dir("to_style", exclude_files = exclude_files))
+
+    result_app_1_no_style <- xfun::read_utf8("to_style/app/__init__.R")
+    expected_app_1_no_style <- xfun::read_utf8(fs::path(to_style_path, "app", "__init__.R"))
+
+    expect_identical(result_app_1_no_style, expected_app_1_no_style)
   })
 })

--- a/tests/testthat/to_style/app/__init__.R
+++ b/tests/testthat/to_style/app/__init__.R
@@ -1,0 +1,2 @@
+# Some comment
+# Another comment


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #134

## Description
* Allows exclusion of files via regex format.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
