### PR TITLE
[CRITICAL BUG] Skip styling if no box::use() is found

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.3
+Version: 0.10.3.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # box.linters (development version)
 
 * Fix critical bug of style_box_use_*() converting all lines to NA if there is no `box::use()` call found.
+* R version (>= 4.3.0) compatibility fix for MacOS.
 
 # box.linters 0.10.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# box.linters (developlment version)
+# box.linters (development version)
 
 * Fix critical bug of style_box_use_*() converting all lines to NA if there is no `box::use()` call found.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (developlment version)
+
+* Fix critical bug of style_box_use_*() converting all lines to NA if there is no `box::use()` call found.
+
 # box.linters 0.10.3
 
 * Implement `exclude_files` in `style_box_use_dir()` to exclude files from styling.

--- a/R/namespaced_function_calls.R
+++ b/R/namespaced_function_calls.R
@@ -45,7 +45,12 @@ namespaced_function_calls <- function(allow = NULL) {
         "namespaced_function_calls(). They require R version >= 4.3.0."
       )
     )
-    return()
+
+    return(
+      lintr::Linter(function(source_expression) {
+        return(list())
+      })
+    )
   }
 
   always_allow <- c("box")

--- a/R/style_box_use.R
+++ b/R/style_box_use.R
@@ -111,6 +111,9 @@ transform_file <- function(filename, indent_spaces, trailing_commas_func) {
   source_file_lines <- xfun::read_utf8(normal_filename)
 
   box_lines <- find_box_lines(paste(source_file_lines, collapse = "\n"))
+  if (length(box_lines$all) == 0) {
+    return(FALSE)
+  }
   retain_lines <- find_source_lines_to_retain(source_file_lines, box_lines)
 
   transformed_box_use <- transform_box_use_text(
@@ -180,6 +183,10 @@ style_box_use_text <- function(
   source_text_lines <- stringr::str_split_1(text, "\n")
 
   box_lines <- find_box_lines(text)
+  if (length(box_lines$all) == 0) {
+    cli::cli_alert_info("No `box::use()` calls found. No changes were made to the text.")
+    return(invisible(text))
+  }
   retain_lines <- find_source_lines_to_retain(source_text_lines, box_lines)
 
   transformed_text <- transform_box_use_text(text, indent_spaces, trailing_commas_func)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,9 @@
 r_version_compatibility <- function() {
-  namespaced_function_calls()
+  if (getRversion() >= 4.3) {
+    namespaced_function_calls()
+  } else {
+    NULL
+  }
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 r_version_compatibility <- function() {
-  if (as.numeric(R.Version()$major) >= 4 & as.numeric(R.Version()$minor) >= 3.0) {
+  if (as.numeric(R.Version()$major) >= 4 && as.numeric(R.Version()$minor) >= 3.0) {
     namespaced_function_calls()
   } else {
     NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,11 @@ rhino_default_linters <- lintr::modify_defaults(
   box_unused_att_pkg_linter = box_unused_attached_pkg_linter(),
   box_unused_attached_pkg_fun_linter = box_unused_att_pkg_fun_linter(),
   box_usage_linter = box_usage_linter(),
-  namespaced_function_calls = namespaced_function_calls(),
+  namespaced_function_calls = if (getRversion() >= 4.3) {
+    namespaced_function_calls()
+  } else {
+    NULL
+  },
   r6_usage_linter = r6_usage_linter(),
   unused_declared_object_linter = unused_declared_object_linter(),
   object_usage_linter = NULL  # Does not work with `box::use()`
@@ -50,7 +54,11 @@ box_default_linters <- lintr::modify_defaults(
   box_unused_att_pkg_linter = box_unused_attached_pkg_linter(),
   box_unused_attached_pkg_fun_linter = box_unused_att_pkg_fun_linter(),
   box_usage_linter = box_usage_linter(),
-  namespaced_function_calls = namespaced_function_calls(),
+  namespaced_function_calls = if (getRversion() >= 4.3) {
+    namespaced_function_calls()
+  } else {
+    NULL
+  },
   r6_usage_linter = r6_usage_linter(),
   unused_declared_object_linter = unused_declared_object_linter(),
   object_usage_linter = NULL  # Does not work with `box::use()`

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,5 @@
 r_version_compatibility <- function() {
-  if (getRversion() >= 4.3) {
+  if (as.numeric(R.Version()$major) >= 4 & as.numeric(R.Version()$minor) >= 3.0) {
     namespaced_function_calls()
   } else {
     NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,8 @@
+r_version_compatibility <- function() {
+  namespaced_function_calls()
+}
+
+
 # nolint start: line_length_linter
 #' Rhino default linters
 #'
@@ -25,11 +30,7 @@ rhino_default_linters <- lintr::modify_defaults(
   box_unused_att_pkg_linter = box_unused_attached_pkg_linter(),
   box_unused_attached_pkg_fun_linter = box_unused_att_pkg_fun_linter(),
   box_usage_linter = box_usage_linter(),
-  namespaced_function_calls = if (getRversion() >= 4.3) {
-    namespaced_function_calls()
-  } else {
-    NULL
-  },
+  namespaced_function_calls = r_version_compatibility(),
   r6_usage_linter = r6_usage_linter(),
   unused_declared_object_linter = unused_declared_object_linter(),
   object_usage_linter = NULL  # Does not work with `box::use()`
@@ -54,11 +55,7 @@ box_default_linters <- lintr::modify_defaults(
   box_unused_att_pkg_linter = box_unused_attached_pkg_linter(),
   box_unused_attached_pkg_fun_linter = box_unused_att_pkg_fun_linter(),
   box_usage_linter = box_usage_linter(),
-  namespaced_function_calls = if (getRversion() >= 4.3) {
-    namespaced_function_calls()
-  } else {
-    NULL
-  },
+  namespaced_function_calls = r_version_compatibility(),
   r6_usage_linter = r6_usage_linter(),
   unused_declared_object_linter = unused_declared_object_linter(),
   object_usage_linter = NULL  # Does not work with `box::use()`

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -5,6 +5,7 @@ Customizable
 Github
 Linter
 Linters
+MacOS
 RStudio
 Rhinoverse
 Treesitter


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #134 

Includes a bugfix for R >= 4.3 compatibility. See comments below.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
