### PR TITLE
Tests fix for treesitter.r 1.1.0 update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
   spelling,
   testthat (>= 3.0.0),
   treesitter,
-  treesitter.r
+  treesitter.r (>= 1.1.0)
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.4
+Version: 0.10.4.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.linters (development version)
+
+* Fix for `treesitter.r` update to version 1.1.0. Change in how treesitter returns the start row of the program node. (#143)
+
 # box.linters 0.10.4
 
 * Fix critical bug of style_box_use_*() converting all lines to NA if there is no `box::use()` call found.

--- a/tests/testthat/test-style_box_use.R
+++ b/tests/testthat/test-style_box_use.R
@@ -528,7 +528,7 @@ box::use(
   ts_tree <- ts_root(code)
   result <- ts_get_start_end_rows(ts_tree)
 
-  expected_result <- list("start" = 1, "end" = 4)
+  expected_result <- list("start" = 0, "end" = 4)
   expect_identical(result, expected_result)
 
   code <- "
@@ -541,7 +541,7 @@ box::use(
   ts_tree <- ts_root(code)
   result <- ts_get_start_end_rows(ts_tree)
 
-  expected_result <- list("start" = 1, "end" = 5)
+  expected_result <- list("start" = 0, "end" = 5)
   expect_identical(result, expected_result)
 })
 


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #143 

## Description
* Changed start rows in tests to correct row 0.
* Using `treesitter.r@1.0.1` and running tests will throw the errors but with values reversed.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
