### PR TITLE
Nothing @export'ed in a box module means all are exported.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.5.9003
+Version: 0.10.5.9004
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # development version
 
+* Support `box` module function for "nothing exported means export all". (#166)
 * Fix for false-positive lint on a list-name function call of a function argument. (#131)
 * Gracefully handle non-existing module error in `box_unused_attached_mod_linter()`. (#108)
 * Support for destructure operator `%<-%`

--- a/R/unused_declared_object_linter.R
+++ b/R/unused_declared_object_linter.R
@@ -56,6 +56,11 @@ unused_declared_object_linter <- function() {
     object_assignments <- get_declared_objects(xml)
     deconstructor_assignments <- get_deconstructor_objects(xml)
     exported_objects <- get_exported_objects(xml)
+
+    if (length(exported_objects$xml_nodes) == 0) {
+      exported_objects <- object_assignments
+    }
+
     function_calls <- get_function_calls(xml)
     special_calls <- get_special_calls(xml)
     object_calls <- get_object_calls(xml)

--- a/tests/testthat/mod/path/to/module_all.R
+++ b/tests/testthat/mod/path/to/module_all.R
@@ -1,0 +1,13 @@
+all_fun_a <- function() {
+  "exported a"
+}
+
+all_fun_b <- function() {
+  "exported b"
+}
+
+all_fun_c <- function() {
+  "private c"
+}
+
+all_obj_a <- 1:3

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -53,7 +53,7 @@ test_that("Should allow modules with nothing exported, and assume all exported -
 
 all_fun_a()"
 
-lintr::expect_lint(code, NULL, linters)
+  lintr::expect_lint(code, NULL, linters)
 })
 
 test_that("Should allow modules with nothing exported, and assume all exported - dots.", {
@@ -66,6 +66,5 @@ test_that("Should allow modules with nothing exported, and assume all exported -
 all_fun_a()
 all_fun_c()"
 
-lintr::expect_lint(code, NULL, linters)
+  lintr::expect_lint(code, NULL, linters)
 })
-

--- a/tests/testthat/test-general.R
+++ b/tests/testthat/test-general.R
@@ -27,3 +27,45 @@ mtcars |>
 
   lintr::expect_lint(code, NULL, linters)
 })
+
+options(box.path = file.path(getwd(), "mod"))
+
+test_that("Should allow modules with nothing exported, and assume all exported - namespaced.", {
+  linters <- lintr::linters_with_defaults(defaults = box.linters::box_default_linters)
+
+  code <- "box::use(
+  path/to/module_all
+)
+
+module_all$all_fun_a()
+module_all$all_fun_c()
+module_all$all_obj_a"
+
+  lintr::expect_lint(code, NULL, linters)
+})
+
+test_that("Should allow modules with nothing exported, and assume all exported - function", {
+  linters <- lintr::linters_with_defaults(defaults = box.linters::box_default_linters)
+
+  code <- "box::use(
+  path/to/module_all[all_fun_a]
+)
+
+all_fun_a()"
+
+lintr::expect_lint(code, NULL, linters)
+})
+
+test_that("Should allow modules with nothing exported, and assume all exported - dots.", {
+  linters <- lintr::linters_with_defaults(defaults = box.linters::box_default_linters)
+
+  code <- "box::use(
+  path/to/module_all[...]
+)
+
+all_fun_a()
+all_fun_c()"
+
+lintr::expect_lint(code, NULL, linters)
+})
+

--- a/tests/testthat/test-unused_declared_object_linter.R
+++ b/tests/testthat/test-unused_declared_object_linter.R
@@ -33,24 +33,23 @@ test_that("unused_declared_object_linter skips used declared functions", {
 
 test_that("unused_declared_object_linter blocks unused declared functions", {
   linter <- unused_declared_object_linter()
-  lint_message <- rex::rex("Declared function/object unused.")
 
-  bad_box_usage_1 <- "sample_fun <- function(x, y) {
+  good_box_usage_1 <- "sample_fun <- function(x, y) {
     x + y
   }
   "
 
-  bad_box_usage_2 <- "assign('x', function(y) {y + 1})
+  good_box_usage_2 <- "assign('x', function(y) {y + 1})
   assign('y', 4)
   "
 
-  bad_box_usage_3 <- 'assign("x", function(y) {y + 1})
+  good_box_usage_3 <- 'assign("x", function(y) {y + 1})
   assign("y", 4)
   '
 
-  lintr::expect_lint(bad_box_usage_1, list(message = lint_message), linter)
-  lintr::expect_lint(bad_box_usage_2, list(message = lint_message), linter)
-  lintr::expect_lint(bad_box_usage_3, list(message = lint_message), linter)
+  lintr::expect_lint(good_box_usage_1, NULL, linter)
+  lintr::expect_lint(good_box_usage_2, NULL, linter)
+  lintr::expect_lint(good_box_usage_3, NULL, linter)
 })
 
 test_that("get_exported_objects returns correct list of exported objects", {
@@ -249,22 +248,6 @@ test_that("unused_declared_object_linter skips literal braces in glue string tem
   lintr::expect_lint(code, NULL, linters = linter)
 })
 
-test_that("unused_declared_object_linter blocks unused objects in glue string templates", {
-  linter <- unused_declared_object_linter()
-  lint_message <- rex::rex("Declared function/object unused.")
-
-  code <- "
-    box::use(
-      glue[glue],
-    )
-
-    some_value <- 4
-    glue(\"This does not have a parseable object.\")
-  "
-
-  lintr::expect_lint(code, list(message = lint_message), linters = linter)
-})
-
 test_that("unused_declared_object_linter blocks unused deconstructor assignments", {
   linter <- unused_declared_object_linter()
   lint_message <- rex::rex("Declared function/object unused.")
@@ -284,4 +267,21 @@ test_that("unused_declared_object_linter blocks unused deconstructor assignments
   "
 
   lintr::expect_lint(code, list(message = lint_message), linter)
+})
+
+test_that("when none are @export'ed, all are @export'ed. Don't lint on unused objects.", {
+  linter <- unused_declared_object_linter()
+
+  code <- "
+foo <- function() {
+
+}
+
+bar <- function() {
+
+}
+
+baz <- 3"
+
+  lintr::expect_lint(code, NULL, linter)
 })


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #165 

## Description
* Added tests for attached modules
* Changed behavior of `unused_declared_object_linter()` to assume all objects are exported if none are exported in the local file. This prevents the "declared function/object unused" lint.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
