### PR TITLE
Change alpha sort method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.5.9005
+Version: 0.10.5.9006
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Support for destructure operator `%<-%`
 * Support for non-syntactic names for objects, functions, module names (#147, #151)
+* Change alphabetical sort to `radix` for cross-platform consistency. (#168)
 
 # box.linters 0.10.5
 

--- a/R/box_alphabetical_calls_linter.R
+++ b/R/box_alphabetical_calls_linter.R
@@ -97,7 +97,7 @@ box_alphabetical_calls_linter <- function() {
     xml <- source_expression$xml_parsed_content
     xml_nodes <- xml2::xml_find_all(xml, xpath)
     modules_called <- xml2::xml_text(xml_nodes)
-    modules_check <- modules_called == sort(modules_called)
+    modules_check <- modules_called == sort(modules_called, method = "radix")
 
     unsorted_modules <- which(modules_check == FALSE)
     module_lint <- lintr::xml_nodes_to_lints(
@@ -112,7 +112,7 @@ box_alphabetical_calls_linter <- function() {
     function_lint <- lapply(xml_nodes_with_functions, function(xml_node) {
       imported_functions <- xml2::xml_find_all(xml_node, xpath_functions)
       functions_called <- xml2::xml_text(imported_functions)
-      functions_check <- functions_called == sort(functions_called)
+      functions_check <- functions_called == sort(functions_called, method = "radix")
       unsorted_functions <- which(functions_check == FALSE)
       unsorted <- any(!functions_check)
 

--- a/R/box_alphabetical_calls_linter.R
+++ b/R/box_alphabetical_calls_linter.R
@@ -4,6 +4,8 @@
 #' Checks that module and function imports are sorted alphabetically. Aliases are
 #' ignored. The sort check is on package/module names and attached function names.
 #'
+#' Alphabetical sort order places upper-case/capital letters first: (A, B, C, a, b, c).
+#'
 #' For use in `rhino`, see the
 #' [Explanation: Rhino style guide](https://appsilon.github.io/rhino/articles/explanation/rhino-style-guide.html)
 #' to learn about the details.
@@ -19,6 +21,11 @@
 #'
 #' lintr::lint(
 #'   text = "box::use(package[functionB, functionA])",
+#'   linters = box_alphabetical_calls_linter()
+#' )
+#'
+#' lintr::lint(
+#'   text = "box::use(bslib, config, dplyr, DT)",
 #'   linters = box_alphabetical_calls_linter()
 #' )
 #'
@@ -45,6 +52,11 @@
 #'
 #' lintr::lint(
 #'   text = "box::use(package[functionA, functionB])",
+#'   linters = box_alphabetical_calls_linter()
+#' )
+#'
+#' lintr::lint(
+#'   text = "box::use(DT, bslib, config, dplyr)",
 #'   linters = box_alphabetical_calls_linter()
 #' )
 #'

--- a/R/style_box_use.R
+++ b/R/style_box_use.R
@@ -300,7 +300,7 @@ sort_mod_pkg_calls <- function(tree_matches, pkg_or_mod = c("mod", "pkg")) {
   )
 
   attached_names <- get_nodes_text_by_type(tree_matches, node_names)
-  order_attached_names <- order(attached_names)
+  order_attached_names <- order(attached_names, method = "radix")
   attached_calls <- get_nodes_text_by_type(tree_matches, node_calls)
   comments <- get_nodes_text_by_type(tree_matches, "comment")
   names(attached_calls) <- comments
@@ -371,7 +371,7 @@ sort_func_calls <- function(call_with_funcs) {
   comments <- get_nodes_text_by_type(call_with_funcs, "comment")
   names(func_calls) <- comments
 
-  order_func_names <- order(func_names)
+  order_func_names <- order(func_names, method = "radix")
   list(
     pkg_mod_name = pkg_mod_name,
     funcs = func_calls[order_func_names]

--- a/man/box_alphabetical_calls_linter.Rd
+++ b/man/box_alphabetical_calls_linter.Rd
@@ -14,6 +14,8 @@ Checks that module and function imports are sorted alphabetically. Aliases are
 ignored. The sort check is on package/module names and attached function names.
 }
 \details{
+Alphabetical sort order places upper-case/capital letters first: (A, B, C, a, b, c).
+
 For use in \code{rhino}, see the
 \href{https://appsilon.github.io/rhino/articles/explanation/rhino-style-guide.html}{Explanation: Rhino style guide}
 to learn about the details.
@@ -27,6 +29,11 @@ lintr::lint(
 
 lintr::lint(
   text = "box::use(package[functionB, functionA])",
+  linters = box_alphabetical_calls_linter()
+)
+
+lintr::lint(
+  text = "box::use(bslib, config, dplyr, DT)",
   linters = box_alphabetical_calls_linter()
 )
 
@@ -53,6 +60,11 @@ lintr::lint(
 
 lintr::lint(
   text = "box::use(package[functionA, functionB])",
+  linters = box_alphabetical_calls_linter()
+)
+
+lintr::lint(
+  text = "box::use(DT, bslib, config, dplyr)",
   linters = box_alphabetical_calls_linter()
 )
 

--- a/tests/testthat/test-box_alphabetical_calls_linter.R
+++ b/tests/testthat/test-box_alphabetical_calls_linter.R
@@ -128,3 +128,43 @@ test_that("box_alphabetical_calls_linter() blocks unsorted imports in box::use()
     list(message = lint_message, line_number = 4, column_number = 19)
   ), linter)
 })
+
+test_that("box_alphabetical_calls_linter() works the same cross-platform", {
+  linter <- box_alphabetical_calls_linter()
+
+  good_order <- "box::use(
+    A,
+    Ab1,
+    B,
+    C.r,
+    a,
+    b,
+    c.A
+  )
+"
+
+  lintr::expect_lint(good_order, NULL, linter)
+
+  lint_message <- rex::rex("Module and function imports must be sorted alphabetically.")
+
+  nix_order <- "box::use(
+    a,
+    A,
+    Ab1,
+    b,
+    B,
+    c.A,
+    C.r
+  )
+"
+
+  lintr::expect_lint(nix_order, list(
+    list(message = lint_message, line_number = 2, column_number = 5),
+    list(message = lint_message, line_number = 3, column_number = 5),
+    list(message = lint_message, line_number = 4, column_number = 5),
+    list(message = lint_message, line_number = 5, column_number = 5),
+    list(message = lint_message, line_number = 6, column_number = 5),
+    list(message = lint_message, line_number = 7, column_number = 5),
+    list(message = lint_message, line_number = 8, column_number = 5)
+  ), linter)
+})

--- a/tests/testthat/test-style_box_use.R
+++ b/tests/testthat/test-style_box_use.R
@@ -1271,6 +1271,32 @@ some_function <- function() {
   expect_output(suppressWarnings(style_box_use_text(code)), expected_output)
 })
 
+test_that("style_box_use_text() has cross-platform consistency", {
+  code <- "box::use(
+  a,
+  A,
+  Ab1,
+  b,
+  B,
+  c.A,
+  C.r
+)
+"
+
+  expected_output <- rex::rex("box::use(
+  A,
+  Ab1,
+  B,
+  C.r,
+  a,
+  b,
+  c.A,
+)
+")
+
+  expect_output(suppressWarnings(style_box_use_text(code)), expected_output)
+})
+
 test_that("style_box_use_text() does not modify when there is no box::use()", {
   code <- "
 some_function <- function() {


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Closes #168 

## Description
* Explicitly use "radix" sort/order method for packages, modules, and functions.
* A, B, C, a, b, c is the only sort/order result available on Windows.
* **It is crucial that cross-platform CI passes**

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
