### PR TITLE
Fix bug where module was linted if we used one list from it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R:
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),
     person("Jakub", "Nowicki", role = "aut", email = "kuba@appsilon.com"),
     person("Mateusz", "Kołomański", role = "ctb", email = "mateusz.kolomanski@appsilon.com"),
+    person("Guilherme", "Vituri", role = "ctb", email = "vituri@appsilon.com"),
     person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com")
   )
 Description: Static code analysis of 'box' modules.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.linters
 Title: Linters for 'box' Modules
-Version: 0.10.5.9007
+Version: 0.10.5.9008
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # development version
 
+* Fixed an issue in `box_unused_attached_pkg_linter()` where list members accessed via `$` were not recognized as usage of the attached package.
 * Support `box` module function for "nothing exported means export all". (#166)
 * Fix for false-positive lint on a list-name function call of a function argument. (#131)
 * Gracefully handle non-existing module error in `box_unused_attached_mod_linter()`. (#108)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # development version
 
-* Fixed an issue in `box_unused_attached_pkg_linter()` where list members accessed via `$` were not recognized as usage of the attached package.
+* Fixed an issue in `box_unused_attached_pkg_linter()` where list members accessed via `$` were not recognized as usage of the attached package. (#148)
 * Support `box` module function for "nothing exported means export all". (#166)
 * Fix for false-positive lint on a list-name function call of a function argument. (#131)
 * Gracefully handle non-existing module error in `box_unused_attached_mod_linter()`. (#108)

--- a/R/box_unused_attached_pkg_linter.R
+++ b/R/box_unused_attached_pkg_linter.R
@@ -82,7 +82,8 @@ box_unused_attached_pkg_linter <- function() {
     function_calls <- get_function_calls(xml)
     glue_object_calls <- get_objects_in_strings(xml)
 
-    all_calls_text <- c(function_calls$text, glue_object_calls)
+    # Add object calls to function calls to detect usage of list-like objects from packages
+    all_calls_text <- c(function_calls$text, glue_object_calls, get_object_calls(xml)$text)
 
     unused_package <- lapply(attached_packages$xml, function(attached_package) {
       package_text <- lintr::get_r_string(attached_package)

--- a/R/box_unused_attached_pkg_linter.R
+++ b/R/box_unused_attached_pkg_linter.R
@@ -81,9 +81,9 @@ box_unused_attached_pkg_linter <- function() {
     attached_three_dots <- get_attached_pkg_three_dots(xml)
     function_calls <- get_function_calls(xml)
     glue_object_calls <- get_objects_in_strings(xml)
+    object_calls <- get_object_calls(xml)
 
-    # Add object calls to function calls to detect usage of list-like objects from packages
-    all_calls_text <- c(function_calls$text, glue_object_calls, get_object_calls(xml)$text)
+    all_calls_text <- c(function_calls$text, glue_object_calls, object_calls$text)
 
     unused_package <- lapply(attached_packages$xml, function(attached_package) {
       package_text <- lintr::get_r_string(attached_package)

--- a/tests/testthat/test-box_unused_attached_pkg_linter.R
+++ b/tests/testthat/test-box_unused_attached_pkg_linter.R
@@ -215,3 +215,16 @@ test_that("box_unused_attached_pkg_linter blocks unused functions in glue string
 
   lintr::expect_lint(bad_box_usage, list(message = lint_message_1), linters = linter)
 })
+
+test_that("box_unused_pkg_linter understands lists imported from modules", {
+  linter <- box_unused_attached_pkg_linter()
+
+  good_box_usage <- "box::use(
+    shiny,
+  )
+
+  shiny$tags$hr()
+  "
+
+  lintr::expect_lint(good_box_usage, NULL, linter)
+})


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #148 

## Description
This is an experimental PR made with Copilot. The complete note can be found in our knowledge base.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
